### PR TITLE
profile-photo-22

### DIFF
--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,62 @@
+import { ChangeEvent, useState } from 'react';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import DeleteIcon from '@material-ui/icons/Delete';
+import useStyles from './useStyles';
+import { User } from '../../interface/User';
+import Avatar from '@material-ui/core/Avatar';
+
+interface Props {
+  loggedInUser: User;
+}
+
+const ProfilePhoto = ({ loggedInUser }: Props): JSX.Element => {
+  const classes = useStyles();
+
+  const [image, setImage] = useState<any>({});
+
+  const handleUpload = (event: ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    console.log(event.target.files);
+    const uploadedImage = event.target.files;
+    setImage(uploadedImage);
+    console.log(image);
+  };
+
+  return (
+    <Grid className={classes.root}>
+      <Box>
+        <Typography className={classes.pageTitle} variant="h1">
+          Profile Photo
+        </Typography>
+      </Box>
+      <Box className={classes.root}>
+        <Avatar
+          className={classes.avatarImage}
+          alt="Profile Image"
+          src={`https://robohash.org/${loggedInUser.email}.png`}
+        />
+        <Typography className={classes.subtext} variant="subtitle1">
+          Be sure to use a photo that clearly shows your face
+        </Typography>
+      </Box>
+      <Box>
+        <input accept="image/*" id="uploadImageButton" type="file" className={classes.input} onChange={handleUpload} />
+        <label htmlFor="uploadImageButton">
+          <Button className={classes.uploadButton} variant="outlined" color="primary" component="span">
+            Upload a file from your device
+          </Button>
+        </label>
+      </Box>
+      <Box>
+        <Grid item className={classes.delete}>
+          <Button startIcon={<DeleteIcon />}>Delete Photo</Button>
+        </Grid>
+      </Box>
+    </Grid>
+  );
+};
+
+export default ProfilePhoto;

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -19,10 +19,8 @@ const ProfilePhoto = ({ loggedInUser }: Props): JSX.Element => {
 
   const handleUpload = (event: ChangeEvent<HTMLInputElement>) => {
     event.preventDefault();
-    console.log(event.target.files);
     const uploadedImage = event.target.files;
     setImage(uploadedImage);
-    console.log(image);
   };
 
   return (

--- a/client/src/components/ProfilePhoto/useStyles.ts
+++ b/client/src/components/ProfilePhoto/useStyles.ts
@@ -1,0 +1,49 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
+  pageTitle: {
+    fontWeight: 'bold',
+    fontSize: 26,
+    margin: 20,
+    fontFamily: theme.typography.fontFamily,
+  },
+  avatarImage: {
+    width: 150,
+    height: 150,
+    margin: 25,
+  },
+  subtext: {
+    width: 175,
+    textAlign: 'center',
+    color: 'gray',
+  },
+  uploadButton: {
+    margin: 35,
+    width: 220,
+    height: 50,
+    borderRadius: theme.shape.borderRadius,
+    fontWeight: 'bold',
+    color: theme.palette.primary.main,
+  },
+  input: {
+    display: 'none',
+  },
+  delete: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    cursor: 'pointer',
+  },
+  deleteText: {
+    paddingLeft: 10,
+    color: 'gray',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { useSocket } from '../../context/useSocketContext';
 import { useHistory } from 'react-router-dom';
 import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import { useEffect } from 'react';
+import ProfilePhoto from '../../components/ProfilePhoto/ProfilePhoto';
 
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();


### PR DESCRIPTION
### What this PR does (required):
- added profile photo component and set up the upload box to upload an image from user's computer

### Screenshots / Videos (required):
- 
![uploadPhotoUI](https://user-images.githubusercontent.com/57962457/131164049-c2dcfa3e-c123-4218-814e-680cb0850c8e.jpg)
![uploadImagePopupWorking](https://user-images.githubusercontent.com/57962457/131164063-cbf7a712-254a-47f3-a1a0-01d7ce6a8169.jpg)

### Any information needed to test this feature (required):
- need to add the ProfilePhoto component to the dashboard page to view it and test the upload box
- 
### Any issues with the current functionality (optional):
- I only made the upload photo UI, the image is still not saved to state or storage (not sure which is better) for sending to the backend and uploading to cloudinary... my next ticket is integrating this functionality and creating the front end routes
